### PR TITLE
Make it easy to use chaining macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ In your namespace declaration:
 ### Create Marathon-Config
 
 Use it in LambdaCD within your build step. For example:
+
 ```clojure
-(defn compile-to-jar
-  [{cwd :cwd {revision :revision} :global} ctx]
-  (let [version (str "0.1." (System/currentTimeMillis))
-        shell-result (shell/bash ctx cwd (str "ci/buildscripts/build.sh " version " " revision))]
-    (assoc shell-result :details [(testng/get-testng-report-as-details "build/reports/tests/testng-results.xml")])))
+(defn test [args ctx]
+  (support/always-chaining args ctx
+    (shell/bash ctx (:cwd args) "mvn test")
+    (parse-testng-report (:cwd args) "target/surefire-reports/testng-results.xml")))
 ```
 
 ### Screenshots

--- a/src/lambdacd_testng/core.clj
+++ b/src/lambdacd_testng/core.clj
@@ -2,7 +2,8 @@
   (:require [clojure.xml :as xml]
             [clojure.zip :as zip]
             [com.rpl.specter :refer :all]
-            [clojure.string :as s]))
+            [clojure.string :as s]
+            [clojure.java.io :as io]))
 
 (defn parse-xml-file [filename]
   (-> (slurp filename)
@@ -77,3 +78,7 @@
         (success-result))
     (catch Exception e
       (error-result (.getMessage e)))))
+
+(defn parse-testng-report [cwd relative-path]
+  {:status  :success
+   :details [(get-testng-report-as-details (io/file cwd relative-path))]})


### PR DESCRIPTION
Adds a convenience method that makes it easier to use lambdacd-testng in the new [chaining-macros](https://github.com/flosell/lambdacd/wiki/Step-Support#chaining-args-ctx--forms) and demonstrates usage in README. 

For a full example, see https://github.com/flosell/lambdacd-testng-demo